### PR TITLE
Support HEAD Requests

### DIFF
--- a/schort.py
+++ b/schort.py
@@ -12,16 +12,8 @@ def short(shortLink=""):
 		if shortLink:
 			noauto = shortLink[-1] == "+"
 			if noauto: shortLink = shortLink[:-1]
-			conn = sqlite3.connect("data/links.sqlite")
-			c = conn.cursor()
-			result = c.execute('SELECT longLink FROM links WHERE shortLink=?', (shortLink, )).fetchone()
-			conn.close()
-			if result:
-				url = result[0]
-				parsedUrl = urlparse(url)
-				if parsedUrl.scheme == "":
-					url = "http://" + url
-
+			url = retrieveUrlFromShortLink(shortLink)
+			if url is not None:
 				if "resolve" in request.args:
 					return escape(url)
 				else:
@@ -43,6 +35,20 @@ def short(shortLink=""):
 
 		databaseId = insertIdUnique(longUrl, idToCheck=wishId)
 		return request.url_root + databaseId # Short link in plain text
+
+def retrieveUrlFromShortLink(shortLink):
+	conn = sqlite3.connect("data/links.sqlite")
+	c = conn.cursor()
+	result = c.execute ('SELECT longLink FROM links WHERE shortLink=?', (shortLink, )).fetchone()
+	conn.close()
+	if result:
+		url = result[0]
+		parsedUrl = urlparse(url)
+		if parsedUrl.scheme == "":
+			url = "http://" + url
+		return url
+	else:
+		return None
 
 def insertIdUnique(longUrl, idToCheck=None):
 	hashUrl = hashlib.sha256(longUrl.encode()).digest()

--- a/schort.py
+++ b/schort.py
@@ -24,7 +24,7 @@ def short(shortLink=""):
 					else:
 						return redirect(url, code=301) # Redirect to long URL saved in the database
 			else:
-				return render_template("index.html", name=shortLink, message="Enter long URL for "+ request.url_root + shortLink+":", message_type="info") # Custom link page
+				return render_template("index.html", name=shortLink, message="Enter long URL for "+ request.url_root + shortLink+":", message_type="info"), 404 # Custom link page
 		else:
 			return render_template("index.html", name=shortLink) # Landing page
 	elif request.method == "POST": # Someone submitted a new link to short

--- a/schort.py
+++ b/schort.py
@@ -8,7 +8,7 @@ app = Flask(__name__)
 @app.route('/', methods=['GET', 'POST'])
 @app.route('/<shortLink>', methods=['GET', 'POST'])
 def short(shortLink=""):
-	if request.method == "GET":
+	if request.method == "GET" or request.method == "HEAD":
 		if shortLink:
 			noauto = shortLink[-1] == "+"
 			if noauto: shortLink = shortLink[:-1]

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -20,7 +20,16 @@ class WebTestCase(object):
 	def assertGetStatusReq(self, expected_status, url, params = {}):
 		req = requests.get(url, params=params, allow_redirects=False)
 		self.assertEqual(req.status_code, expected_status, msg="Returned status code does not match the expected one")
+		return req
 
+	def assertHeadReq(self, url, params = {}):
+		req = requests.head(url, params=params)
+		self.assertEqual(req.status_code, 200, msg="Head request unsuccessful")
+		return req
+
+	def assertHeadStatusReq(self, expected_status, url, params = {}):
+		req = requests.head(url, params=params, allow_redirects=False)
+		self.assertEqual(req.status_code, expected_status, msg="Returned status code does not match the expected one")
 		return req
 
 
@@ -67,9 +76,20 @@ class SchortShortLinkCase(object):
 		loc = req.headers.get("location")
 		self.assertEqual(loc, self.shortDest)
 
+	def test_redirect_head(self):
+		"""Test basic redirecting capability of schort for head requests"""
+		req = self.assertHeadStatusReq(301, BASE_URL + "/" + self.shortID)
+		loc = req.headers.get("location")
+		self.assertEqual(loc, self.shortDest)
+
 	def test_redirect_follow(self):
 		"""Test if the requests-lib can follow the redirect"""
 		req = requests.get(BASE_URL + "/" + self.shortID, allow_redirects=True)
+		req.url = self.shortDest
+
+	def test_redirect_follow_head(self):
+		"""Test if the request lib can follow the redirect in a HEAD request"""
+		req = requests.head(BASE_URL + "/" + self.shortID, allow_redirects=True)
 		req.url = self.shortDest
 
 	def test_resolve(self):


### PR DESCRIPTION
schort now supports HEAD requests.

Upon a HEAD request, the shortlink is being resolved and the request is redirected to the full URL. Thus, the curl request stated in #3 resolves the shortlink and returns the full URL in the `Location` header. If the redirect is being followed, it returns the headers of the full URL, as it is expected from a HEAD request.