### PR TITLE
Explicitly specify necessary file encoding for newer python

### DIFF
--- a/schort.py
+++ b/schort.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from flask import Flask, render_template, url_for, request, redirect, abort, escape
 import sqlite3, random, string, time, hashlib, base64
 from urllib.parse import urlparse


### PR DESCRIPTION
Newer python versions seem to be more strict regarding non-ASCII
characters in source code. In schort.py the character "…" is used so
schort.py failed for me on an upgraded openSUSE Leap 15.3 running
python3.6. Adding a specific coding magic comment fixes that.