### PR TITLE
Handle path after short link

### DIFF
--- a/schort.py
+++ b/schort.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from flask import Flask, render_template, url_for, request, redirect, abort, escape
+from flask import Flask, render_template, url_for, request, redirect, abort
+from markupsafe import escape
 import sqlite3, random, string, time, hashlib, base64
 from urllib.parse import urlparse
 
@@ -9,13 +10,15 @@ app = Flask(__name__)
 
 @app.route('/', methods=['GET', 'POST'])
 @app.route('/<shortLink>', methods=['GET', 'POST'])
-def short(shortLink=""):
+@app.route('/<shortLink>/<path:path>', methods=['GET', 'POST'])
+def short(shortLink="", path=None):
 	if request.method == "GET" or request.method == "HEAD":
 		if shortLink:
 			noauto = shortLink[-1] == "+"
 			if noauto: shortLink = shortLink[:-1]
 			url = retrieveUrlFromShortLink(shortLink)
 			if url is not None:
+				if path: url = url + "/" + path
 				if "resolve" in request.args:
 					return escape(url)
 				else:

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,56 +1,77 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>schort</title>
-			<link rel="stylesheet" href="static/css/index.css">
-	</head>
-	<body>
-		<div id="main">
-			<div id="message" class="{{message_type}}">
-				{{message}}
-			</div>
-			<form action="/" method="post" id="short_form">
-				<span id="url_text">URL:</span>
-				<input type="url" name="url" id="url_input" required>
-				<input type="hidden" name="wishId" value="{{name}}">
-				<input type="submit" value="Schort!" id="short_button">
-			</form>
-			<div id="infobar">
-				<span class="infoitem">
-					<a href="">
-						<div class="link">API</div>
-						<div class="description">
-							<ul>
-								<li>API</li>
-								<div>There is no dedicated API for schort. Just make a POST-request to / with the parameter "url" set to your desired destination. Schort will generate an id for your and gives back the short link in plain text.</div>
-								<br/>
-								<li>Creation of new links</li>
-								<div>If you wish to create a custom URL with your script, you can also set the parameter "wishId". If the requested id is free, schort will print out the short link with your requested id. If not, schort will just generate one and print that one out.</div>
-								<br/>
-								<li>Resolving links</li>
-								<div>To resolve a link you just have to make a GET-request and add the "resolve" parameter. The value of this parameter doesn't matter and gets ignored. This makes schort to print out a plain text string of the original URL.</div>
-							</ul>
-						</div>
-					</a>
-				</span>
-				<span class="infoitem">
-					<a href="">
-						<div class="link">FAQ</div>
-						<div class="description">
-							<ul>
-								<li>Can i produce custom links?</li>
-								<div>Just open /&ltyourWishId&gt. If you get no redirect, you can enter your URL according to your custom id.</div>
-								<li>How can i inspect an shortened link?</li>
-								<div>Append a plus sign ("+") to your short URL. You'll receive a clickable link to the remote destination.</div>
-								<li>How can my script resolve a shortened link?</li>
-								<div>Take a look at the API.</div>
-							</ul>
-						</div>
-					</a>
-				</span>
-				<span class="infoitem"><a href="https://github.com/Sqozz/schort" target="_blank" id="githubLink"><svg aria-hidden="true" class="octicon octicon-mark-github" height="15" role="img" version="1.1" viewBox="0 0 16 16" width="15"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg> github.com</a></span>
-			</div>
+
+<head>
+	<meta charset="utf-8">
+	<title>schort</title>
+	<link rel="stylesheet" href="static/css/index.css">
+</head>
+
+<body>
+	<div id="main">
+		<div id="message" class="{{message_type}}">
+			{{message}}
 		</div>
-	</body>
+		<form action="/" method="post" id="short_form">
+			<span id="url_text">URL:</span>
+			<input type="url" name="url" id="url_input" required>
+			<input type="hidden" name="wishId" value="{{name}}">
+			<input type="submit" value="Schort!" id="short_button">
+		</form>
+		<div id="infobar">
+			<span class="infoitem">
+				<a href="">
+					<div class="link">API</div>
+					<div class="description">
+						<ul>
+							<li>API</li>
+							<div>There is no dedicated API for schort. Just make a POST-request to / with the parameter
+								"url" set to your desired destination. Schort will generate an id for your and gives
+								back the short link in plain text.</div>
+							<br />
+							<li>Creation of new links</li>
+							<div>If you wish to create a custom URL with your script, you can also set the parameter
+								"wishId". If the requested id is free, schort will print out the short link with your
+								requested id. If not, schort will just generate one and print that one out.</div>
+							<br />
+							<li>Resolving links</li>
+							<div>To resolve a link you just have to make a GET-request and add the "resolve" parameter.
+								The value of this parameter doesn't matter and gets ignored. This makes schort to print
+								out a plain text string of the original URL.</div>
+							<li>Resolving links with subpath</li>
+							<div>A subpath can be appended to a short link (ie:
+								&lt;short-link&gt;/path/to/resource.extension)
+								to make things easier for other tools.</div>
+						</ul>
+					</div>
+				</a>
+			</span>
+			<span class="infoitem">
+				<a href="">
+					<div class="link">FAQ</div>
+					<div class="description">
+						<ul>
+							<li>Can i produce custom links?</li>
+							<div>Just open /&ltyourWishId&gt. If you get no redirect, you can enter your URL according
+								to your custom id.</div>
+							<li>How can i inspect an shortened link?</li>
+							<div>Append a plus sign ("+") to your short URL. You'll receive a clickable link to the
+								remote destination.</div>
+							<li>How can my script resolve a shortened link?</li>
+							<div>Take a look at the API.</div>
+						</ul>
+					</div>
+				</a>
+			</span>
+			<span class="infoitem"><a href="https://github.com/Sqozz/schort" target="_blank" id="githubLink"><svg
+						aria-hidden="true" class="octicon octicon-mark-github" height="15" role="img" version="1.1"
+						viewBox="0 0 16 16" width="15">
+						<path
+							d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z">
+						</path>
+					</svg> github.com</a></span>
+		</div>
+	</div>
+</body>
+
 </html>

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -75,6 +75,14 @@ class SchortShortLinkCase(object):
 		req = self.assertGetStatusReq(301, BASE_URL + "/" + self.shortID)
 		loc = req.headers.get("location")
 		self.assertEqual(loc, self.shortDest)
+	
+	def test_redirect_with_subpath(self):
+		"""Test basic redirecting capabilites of schort with subpath"""
+		self.assertNotEqual(len(self.shortID), 0)
+		subpath = "/blob/master/templates/index.html"
+		req = self.assertGetStatusReq(301, BASE_URL + "/" + self.shortID + subpath)
+		loc = req.headers.get("location")
+		self.assertEqual(loc, self.shortDest + subpath)
 
 	def test_redirect_head(self):
 		"""Test basic redirecting capability of schort for head requests"""


### PR DESCRIPTION
#### Description

Add route for handling path of this kind: `<shorten-url><path>` Some tools like libzypp needs support for this,  for example, http://updates.suse.com returns error 404 for the / path but the /repodata/repomd.xml file is served correctly.

#### Example of use
Example of use: curl -vI http://127.0.0.1:5000/9og4/repodata/repomd.xml